### PR TITLE
bug: The advanced search component was not intializing the QueryManag…

### DIFF
--- a/app/public/client/app/components/advanced/components/advanced.js
+++ b/app/public/client/app/components/advanced/components/advanced.js
@@ -189,6 +189,11 @@
       QueryStack.clear();
 
       /**
+       * Initialize the advanced search asset id to 0 (global search)
+       */
+      QueryManager.setAssetId(0);
+
+      /**
        * Hide the result components on init.
        * @type {boolean}
        */


### PR DESCRIPTION
…er AssetId to zero on load.

When executing a global search without selecting collection or community from pulldown, search failed or executed query (or prior asset id which sometimes works!)  Added call to QueryManager.setAssetId(0) to init method.

Issues: AC-731