### PR TITLE
bug: Removed final 'auth' parameter from the solr query session url.

### DIFF
--- a/app/controllers/solr.js
+++ b/app/controllers/solr.js
@@ -47,7 +47,7 @@ var constants = require('../core/constants');
 
     // Sets session url for initial query.
     if (req.body.params.query.qType === constants.QueryType.DISCOVER) {
-     req.session.url = '/ds/discover/' + type + '/' + id + '/' + term + '/0';
+     req.session.url = '/ds/discover/' + type + '/' + id + '/' + term;
     }
 
     var session = req.session;

--- a/app/public/client/ds-app/app/services/core/utils.js
+++ b/app/public/client/ds-app/app/services/core/utils.js
@@ -496,7 +496,6 @@
           CheckSession.query().$promise.then(function (sessionStatus) {
             // If no DSpace session, redirect to authentication.
             if (sessionStatus.status !== 'ok') {
-              console.log('checking session status with auth/login')
               // This sets the Express session url. This will be used in
               // the redirect after authentication succeeds.
               SetAuthUrl.query({url: utils.encodePath(path)}).$promise.then(function () {


### PR DESCRIPTION
For Chrome, the existence of this parameter in queries that produce zero results caused community/collection information to not be available in the search form. After an earlier
review of the auto login sequence I added a TODO to investigate whether this parameter was being used.

Issues: AC-1186